### PR TITLE
Fix IE 11 detection.

### DIFF
--- a/wsgate/webroot/js/mootools-debug.js
+++ b/wsgate/webroot/js/mootools-debug.js
@@ -827,14 +827,14 @@ var window = document.window = this;
 
 var ua = navigator.userAgent.toLowerCase(),
 	platform = navigator.platform.toLowerCase(),
-	UA = ua.match(/(opera|ie|firefox|chrome|version)[\s\/:]([\w\d\.]+)?.*?(safari|version[\s\/:]([\w\d\.]+)|$)/) || [null, 'unknown', 0],
-	mode = UA[1] == 'ie' && document.documentMode;
+	UA = ua.match(/(opera|ie|trident|firefox|chrome|version)[\s\/:]([\w\d\.]+)?.*?(safari|version[\s\/:]([\w\d\.]+)|$)/) || [null, 'unknown', 0],
+	mode = (UA[1] == 'ie' || UA[1] == 'trident') && document.documentMode;
 
 var Browser = this.Browser = {
 
 	extend: Function.prototype.extend,
 
-	name: (UA[1] == 'version') ? UA[3] : UA[1],
+	name: (UA[1] == 'version') ? UA[3] : (UA[1] == 'trident' ? 'ie' : UA[1]),
 
 	version: mode || parseFloat((UA[1] == 'opera' && UA[4]) ? UA[4] : UA[2]),
 


### PR DESCRIPTION
IE 11 detection is broken on Mootools. This fix is based on
https://github.com/dez87/mootools-core/commit/c5c2e178665f1514d7f21ceb2c7671388c017d1a
with a minor tweak for proper version detection.
